### PR TITLE
Edit app_options' platform requirements

### DIFF
--- a/app_options/package.json
+++ b/app_options/package.json
@@ -3,8 +3,8 @@
 	"version": "1.0.0",
 	"nativescript": {
 		"platforms": {
-			"android": "1.5.0",
-			"ios": "1.5.0"
+			"android": "1.3.0",
+			"ios": "1.3.0"
 		}
 	}
 }


### PR DESCRIPTION
Merging configuration files from plugins was introduced in {N} Version 1.3.0, so there's no point in requiring 1.5.0 for this plugin
Ping @PanayotCankov @rosen-vladimirov 