### PR TITLE
Delete references.d.ts

### DIFF
--- a/app/references.d.ts
+++ b/app/references.d.ts
@@ -1,1 +1,0 @@
-/// <reference path="../node_modules/tns-core-modules/tns-core-modules.d.ts" /> Enable smart suggestions and completions in Visual Studio Code JavaScript projects.


### PR DESCRIPTION
The file is redundant, because it will be auto-generated upon $ npm install by the nativescript-dev-typescript module.